### PR TITLE
Adding external rider waite images link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ npm run dev
 
 ---
 
+## External resources
+If you are looking for images to complement your tarot app, the Rider Waite 1909 deck is public domain. You can find images of the cards here: https://www.sacred-texts.com/tarot/xr/index.htm
+
 ## 🗞 Updates
 
 ### 2021/01/25


### PR DESCRIPTION
Feel free to ignore this, but I figured many people finding this API may also be looking for images to complement the text in your API, so I thought a link to a resources that hosts the relevant images could help.

Maybe this also warrants an additional field in the json so cards have urls (either hosted by gihub or external url to the sacred-text website).
Happy to add that if you believe it makes sense.